### PR TITLE
fixing problem with tls version numbers in deployment.json

### DIFF
--- a/dockerfiles/nginx/ecs.conf.template
+++ b/dockerfiles/nginx/ecs.conf.template
@@ -83,7 +83,7 @@ server {
     ssl_session_cache shared:SSL:50m;
     ssl_session_tickets off;
     ssl_dhparam /etc/nginx/ssl/dhparam.pem;
-    ssl_protocols "%TLS_VERSIONS%";
+    ssl_protocols %TLS_VERSIONS%;
     ssl_ciphers "%TLS_CIPHERS%";
     ssl_prefer_server_ciphers on;
 
@@ -129,7 +129,7 @@ server {
     ssl_session_cache shared:SSL:50m;
     ssl_session_tickets off;
     ssl_dhparam /etc/nginx/ssl/dhparam.pem;
-    ssl_protocols "%TLS_VERSIONS%";
+    ssl_protocols %TLS_VERSIONS%;
     ssl_ciphers "%TLS_CIPHERS%";
     ssl_prefer_server_ciphers on;
 


### PR DESCRIPTION
Hi Dave, 

we ran into problems with nginx with the TLS versions.
nginx does not expect the list of TLS versions in quotes, so we removed them from this template.
